### PR TITLE
Change backend hosting from Render to Railway (attempt v3)

### DIFF
--- a/client/modules/leaderboard.js
+++ b/client/modules/leaderboard.js
@@ -4,7 +4,7 @@ export function leaderboard() {
   console.log("leaderboard.js active");
 }
 
-const url = "https://traffic-browser-game-b0ad.onrender.com/";
+const url = "https://car-browser-game-car-browser-game-pr-2.up.railway.app/";
 let firstload = true;
 
 const party = {

--- a/client/modules/leaderboard.js
+++ b/client/modules/leaderboard.js
@@ -4,7 +4,7 @@ export function leaderboard() {
   console.log("leaderboard.js active");
 }
 
-const url = "https://car-browser-game-car-browser-game-pr-2.up.railway.app/";
+const url = "https://car-browser-game-car-browser-game-pr-3.up.railway.app/";
 let firstload = true;
 
 const party = {

--- a/client/modules/leaderboard.js
+++ b/client/modules/leaderboard.js
@@ -4,7 +4,7 @@ export function leaderboard() {
   console.log("leaderboard.js active");
 }
 
-const url = "https://car-browser-game-car-browser-game-pr-3.up.railway.app/";
+const url = "https://car-browser-game-production.up.railway.app/";
 let firstload = true;
 
 const party = {

--- a/client/rc-tv/tv.js
+++ b/client/rc-tv/tv.js
@@ -1,7 +1,7 @@
 console.log("Hello world");
 
 const tbody = document.querySelector("tbody");
-const url = "https://car-browser-game-car-browser-game-pr-3.up.railway.app/";
+const url = "https://car-browser-game-production.up.railway.app/";
 
 function refreshLeaderboard(partyId) {
   tbody.innerHTML = "";

--- a/client/rc-tv/tv.js
+++ b/client/rc-tv/tv.js
@@ -1,7 +1,7 @@
 console.log("Hello world");
 
 const tbody = document.querySelector("tbody");
-const url = "https://traffic-browser-game-b0ad.onrender.com/";
+const url = "https://car-browser-game-car-browser-game-pr-3.up.railway.app/";
 
 function refreshLeaderboard(partyId) {
   tbody.innerHTML = "";

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,11 @@ getPgVersion();
 
 /* ROUTE HANDLERS */
 
+// CHECK IF SERVER IS LIVE ON DEPLOYMENT
+app.get("/", (req, res) => {
+  res.status(200).send({ message: "Welcome to the Server" });
+});
+
 // REFRESHES LEADERBOARD
 app.get("/refresh-leaderboard/:partyId", async (req, res) => {
   try {


### PR DESCRIPTION
Given that Render shuts down its web service due to inactivity and takes ~1min to boot back up, I've moved the backend to Railway for more consistent uptime.